### PR TITLE
Added changes to readme based on my use in the Fall 2018 course

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,13 +9,13 @@ This docker image is based off of the ubuntu:16.04 image and adds the `gcc`, `g+
 
 To quickly get going with Cilk Plus, execute `docker run -it --rm jonniesweb/cilkplus` for a bash shell where you can then start using GCC.
 
-It's more helpful to mount the directory with your code into the container, that way you can edit the code from your host and execute `gcc`/`g++` from inside of the container. To mount the current directory you are in, you can use,
+It's more helpful to mount the directory with your code into the container, that way you can edit the code from your host and execute `gcc`/`g++` from inside of the container. To mount the current directory you are in, you can use:
 
 ```
-docker run -it --rm -v $(pwd):/root/a1 -w /root/a1 jonniesweb/cilkplus
+docker run -it --rm -v $(pwd):/app -w /app jonniesweb/cilkplus
 ```
 
-To compile your Cilk files, make sure to use the compiler option `-std=c++0x` to force use of C++11. Also, use `-fcilkplus` to allow use of Cilk in your program. For example, if you wanted to compile main.cpp, you might use this command,
+To compile your Cilk files, make sure to use the compiler option `-std=c++0x` to force use of C++11. Also, use `-fcilkplus` to allow use of Cilk in your program. For example, if you wanted to compile main.cpp, you might use this command:
 
 ```
 g++ -std=c++0x main.cpp -O3 -fcilkplus -o main

--- a/README.md
+++ b/README.md
@@ -1,16 +1,24 @@
 # docker-cilkplus
 A small and simple dev environment for building and running C/C++ Cilk Plus applications with the GNU Compiler. This image was specifically built to avoid using the 4GB virtual machine image that is provided for the COMP 4009 Fall 2016 course at Carleton University.
 
+This was most recently tested for COMP 4009 A1 in Fall 2018.
+
 This docker image is based off of the ubuntu:16.04 image and adds the `gcc`, `g++`, `make`, `vim` and `valgrind` packages.
 
 # Using
 
 To quickly get going with Cilk Plus, execute `docker run -it --rm jonniesweb/cilkplus` for a bash shell where you can then start using GCC.
 
-It's more helpful to mount the directory with your code into the container, that way you can edit the code from your host and execute `gcc`/`g++` from inside of the container. eg.
+It's more helpful to mount the directory with your code into the container, that way you can edit the code from your host and execute `gcc`/`g++` from inside of the container. To mount the current directory you are in, you can use,
 
 ```
-docker run -it --rm -v /home/jon/git/comp-4009/a1:/root/a1 jonniesweb/cilkplus
+docker run -it --rm -v $(pwd):/root/a1 -w /root/a1 jonniesweb/cilkplus
+```
+
+To compile your Cilk files, make sure to use the compiler option `-std=c++0x` to force use of C++11. Also, use `-fcilkplus` to allow use of Cilk in your program. For example, if you wanted to compile main.cpp, you might use this command,
+
+```
+g++ -std=c++0x main.cpp -O3 -fcilkplus -o main
 ```
 
 # Misc


### PR DESCRIPTION
Hey Jon,

I made some changes to the readme to include better ease of use for the Fall 2018 course, based on how I used the image in the first assignment.

I changed
`docker run -it --rm -v /home/jon/git/comp-4009/a1:/root/a1 jonniesweb/cilkplus`
to
`docker run -it --rm -v $(pwd):/root/a1 -w /root/a1 jonniesweb/cilkplus`
so that it would launch the folder you are currently in, as well as set it as the working directory. That way, when you open the image's terminal, you are already in the folder that you were in outside of the image.

I also added a sample compile command,
`g++ -std=c++0x main.cpp -O3 -fcilkplus -o main`
It specifies that C++11 should be forced, as that was something I ran into. I didn't debug it fully, however I was unable to use stoi(), a function new to C++11 until I added that flag.

If there are any concerns with this PR, I'll be more than happy to resolve them :smile: 